### PR TITLE
Fix loading of frontend env vars

### DIFF
--- a/apps/admin/app/layout.tsx
+++ b/apps/admin/app/layout.tsx
@@ -1,5 +1,4 @@
 import type { Metadata, Viewport } from 'next';
-import Script from 'next/script';
 import type { ReactNode } from 'react';
 
 import { AppProviders } from 'components/common/AppProviders';
@@ -44,7 +43,8 @@ export default async function RootLayout({
     <html lang='en' dir='ltr'>
       <body>
         {/* load env vars for the frontend - note that the parent body tag is required for React to not complain */}
-        <Script src='/__ENV.js' />
+        {/* eslint-disable-next-line @next/next/no-sync-scripts */}
+        <script src='/__ENV.js' />
         <AppProviders>{children}</AppProviders>
       </body>
     </html>

--- a/apps/scoutgame/app/layout.tsx
+++ b/apps/scoutgame/app/layout.tsx
@@ -2,7 +2,6 @@ import { getCachedUserFromSession as getUserFromSession } from '@packages/scoutg
 import { AppProviders } from '@packages/scoutgame-ui/providers/AppProviders';
 import type { Metadata, Viewport } from 'next';
 import dynamic from 'next/dynamic';
-import Script from 'next/script';
 import type { ReactNode } from 'react';
 
 import '@packages/scoutgame-ui/theme/styles.scss';
@@ -70,7 +69,8 @@ export default async function RootLayout({
     <html lang='en' dir='ltr' suppressHydrationWarning>
       <body>
         {/* load env vars for the frontend - note that the parent body tag is required for React to not complain */}
-        <Script strategy='beforeInteractive' src='/__ENV.js' />
+        {/* eslint-disable-next-line @next/next/no-sync-scripts */}
+        <script src='/__ENV.js' />
         <AppProviders user={user}>
           <ClientGlobals userId={user?.id} />
           {/* {user?.id && <NotificationRequest vapidPublicKey={vapidPublicKey} />} */}

--- a/apps/telegram/app/layout.tsx
+++ b/apps/telegram/app/layout.tsx
@@ -2,7 +2,6 @@ import { getCachedUserFromSession as getUserFromSession } from '@packages/scoutg
 import { AppProviders } from '@packages/scoutgame-ui/providers/AppProviders';
 import type { Metadata, Viewport } from 'next';
 import dynamic from 'next/dynamic';
-import Script from 'next/script';
 import type { ReactNode } from 'react';
 
 import '@packages/scoutgame-ui/theme/styles.scss';
@@ -73,7 +72,8 @@ export default async function RootLayout({
     <html lang='en' dir='ltr' suppressHydrationWarning>
       <body>
         {/* load env vars for the frontend - note that the parent body tag is required for React to not complain */}
-        <Script strategy='beforeInteractive' src='/__ENV.js' />
+        {/* eslint-disable-next-line @next/next/no-sync-scripts */}
+        <script src='/__ENV.js' />
         <AppProviders user={user}>
           <ClientGlobals userId={user?.id} />
           {children}

--- a/packages/mixpanel/src/utils.ts
+++ b/packages/mixpanel/src/utils.ts
@@ -45,23 +45,25 @@ export function getUTMParamsFromSearch(searchString: string): UTMParams | undefi
   };
 }
 
-const platform = env('SCOUTGAME_PLATFORM') || process.env.REACT_APP_SCOUTGAME_PLATFORM;
-
 function isPlatform(_platform: string = ''): _platform is ReferralPlatform {
   const availablePlatforms = Object.values(ReferralPlatform);
 
   return availablePlatforms.includes(_platform as ReferralPlatform);
 }
 
+const initialPlatform = env('SCOUTGAME_PLATFORM') || process.env.REACT_APP_SCOUTGAME_PLATFORM;
+if (!initialPlatform) {
+  log.warn('SCOUTGAME_PLATFORM is not set', { env: typeof window !== 'undefined' ? (window as any).__ENV : null });
+}
+
 export function getPlatform(): ReferralPlatform {
+  const platform = env('SCOUTGAME_PLATFORM') || process.env.REACT_APP_SCOUTGAME_PLATFORM;
   if (isPlatform(platform)) {
     return platform;
   }
 
   if (platform || isProdEnv) {
-    log.warn(`Unknown value for REACT_APP_SCOUTGAME_PLATFORM: ${platform}`, {
-      env: typeof window !== 'undefined' ? (window as any).__ENV : null
-    });
+    log.warn(`Unknown value for REACT_APP_SCOUTGAME_PLATFORM: ${platform}`);
   }
 
   return 'unknown';

--- a/packages/mixpanel/src/utils.ts
+++ b/packages/mixpanel/src/utils.ts
@@ -45,25 +45,23 @@ export function getUTMParamsFromSearch(searchString: string): UTMParams | undefi
   };
 }
 
+const platform = env('SCOUTGAME_PLATFORM') || process.env.REACT_APP_SCOUTGAME_PLATFORM;
+
 function isPlatform(_platform: string = ''): _platform is ReferralPlatform {
   const availablePlatforms = Object.values(ReferralPlatform);
 
   return availablePlatforms.includes(_platform as ReferralPlatform);
 }
 
-const initialPlatform = env('SCOUTGAME_PLATFORM') || process.env.REACT_APP_SCOUTGAME_PLATFORM;
-if (!initialPlatform) {
-  log.warn('SCOUTGAME_PLATFORM is not set', { env: typeof window !== 'undefined' ? (window as any).__ENV : null });
-}
-
 export function getPlatform(): ReferralPlatform {
-  const platform = env('SCOUTGAME_PLATFORM') || process.env.REACT_APP_SCOUTGAME_PLATFORM;
   if (isPlatform(platform)) {
     return platform;
   }
 
   if (platform || isProdEnv) {
-    log.warn(`Unknown value for REACT_APP_SCOUTGAME_PLATFORM: ${platform}`);
+    log.warn(`Unknown value for REACT_APP_SCOUTGAME_PLATFORM: ${platform}`, {
+      env: typeof window !== 'undefined' ? (window as any).__ENV : null
+    });
   }
 
   return 'unknown';


### PR DESCRIPTION
I forget why we used next/script in the first place, but it seems to be loading the script after our code randomly.

I researched quite a bit, it seems like layout.tsx is the earliest chance we have to inject anything in a Next.js app using app router. I found a related issue although it was supposedly fixed: https://github.com/vercel/next.js/issues/49830

To test: refresh the logged-out view many times to see if "Sign In" button appears. If the env vars are loaded, it will appear because REACT_APP_SCOUTGAME_PLATFORM = 'webapp'. About 50% of the time in production the button does not appear.