### PR TITLE
record the correct (local) week for daily claims

### DIFF
--- a/packages/scoutgame-ui/src/components/quests/DailyClaimGallery/DailyClaimCard.tsx
+++ b/packages/scoutgame-ui/src/components/quests/DailyClaimGallery/DailyClaimCard.tsx
@@ -4,6 +4,7 @@ import CheckCircleIcon from '@mui/icons-material/CheckCircle';
 import { Stack, Typography } from '@mui/material';
 import { claimDailyRewardAction } from '@packages/scoutgame/claims/claimDailyRewardAction';
 import type { DailyClaim } from '@packages/scoutgame/claims/getDailyClaims';
+import { getCurrentLocalWeek } from '@packages/scoutgame/dates';
 import { DailyClaimGift } from '@packages/scoutgame-ui/components/claim/components/common/DailyClaimGift';
 import { useUser } from '@packages/scoutgame-ui/providers/UserProvider';
 import { DateTime } from 'luxon';
@@ -54,7 +55,7 @@ export function DailyClaimCard({
       data-test={`daily-claim-${canClaim ? 'enabled' : 'disabled'}`}
       onClick={() => {
         if (canClaim) {
-          claimDailyReward({ isBonus: dailyClaim.isBonus, dayOfWeek: currentWeekDay });
+          claimDailyReward({ isBonus: dailyClaim.isBonus, dayOfWeek: currentWeekDay, week: getCurrentLocalWeek() });
         }
       }}
     >

--- a/packages/scoutgame/src/claims/claimDailyRewardAction.ts
+++ b/packages/scoutgame/src/claims/claimDailyRewardAction.ts
@@ -12,7 +12,8 @@ export const claimDailyRewardAction = authActionClient
     await claimDailyReward({
       userId: ctx.session.scoutId,
       isBonus: parsedInput.isBonus,
-      dayOfWeek: parsedInput.dayOfWeek
+      dayOfWeek: parsedInput.dayOfWeek,
+      week: parsedInput.week
     });
     revalidatePath('/quests');
   });

--- a/packages/scoutgame/src/claims/claimDailyRewardSchema.ts
+++ b/packages/scoutgame/src/claims/claimDailyRewardSchema.ts
@@ -2,5 +2,6 @@ import * as yup from 'yup';
 
 export const claimDailyRewardSchema = yup.object({
   isBonus: yup.boolean(),
-  dayOfWeek: yup.number().required()
+  dayOfWeek: yup.number().required(),
+  week: yup.string().required()
 });

--- a/packages/scoutgame/src/dates.ts
+++ b/packages/scoutgame/src/dates.ts
@@ -42,6 +42,11 @@ export function getCurrentWeek(): ISOWeek {
   return _formatWeek(DateTime.utc());
 }
 
+// used for daily rewards
+export function getCurrentLocalWeek(): ISOWeek {
+  return _formatWeek(DateTime.local());
+}
+
 export function getLastWeek(now: DateTime = DateTime.utc()): ISOWeek {
   return getPreviousWeek(_formatWeek(now));
 }


### PR DESCRIPTION
This fixes a bug that happens if you claim points for the current local week but the new ISOweek has already started.