### PR TITLE
Move NFT mixpanel to webapp/telegram

### DIFF
--- a/apps/cron/.env.ebstalk
+++ b/apps/cron/.env.ebstalk
@@ -39,3 +39,6 @@ REACT_APP_SCOUTPROTOCOL_CONTRIBUTION_RECEIPT_EAS_SCHEMAID="{{pull:secretsmanager
 AIRSTACK_API_KEY="{{pull:secretsmanager:/io.cv.app/prd/farcaster:SecretString:airstack_api_key}}"
 TALENT_PROTOCOL_API_KEY="{{pull:secretsmanager:/io.cv.app/prd/talent:SecretString:api_key}}"
 NEYNAR_API_KEY="{{pull:secretsmanager:/io.cv.app/prd/neynar:SecretString:neynar_api_key}}"
+
+# cron isnt really a platform so we should reconsider the data flow for whatever might be using this
+REACT_APP_SCOUTGAME_PLATFORM=cron

--- a/packages/scoutgame-ui/src/components/common/NFTPurchaseDialog/components/NFTPurchaseForm.tsx
+++ b/packages/scoutgame-ui/src/components/common/NFTPurchaseDialog/components/NFTPurchaseForm.tsx
@@ -43,9 +43,8 @@ import { useCallback, useEffect, useState } from 'react';
 import type { Address } from 'viem';
 import { useAccount, useSwitchChain } from 'wagmi';
 
-import { useTrackEvent } from 'hooks/useTrackEvent';
-
 import { useUserWalletAddress } from '../../../../hooks/api/session';
+import { useTrackEvent } from '../../../../hooks/useTrackEvent';
 import { usePurchase } from '../../../../providers/PurchaseProvider';
 import { useSnackbar } from '../../../../providers/SnackbarContext';
 import { useUser } from '../../../../providers/UserProvider';

--- a/packages/scoutgame-ui/src/components/common/NFTPurchaseDialog/components/NFTPurchaseForm.tsx
+++ b/packages/scoutgame-ui/src/components/common/NFTPurchaseDialog/components/NFTPurchaseForm.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import env from '@beam-australia/react-env';
-import { log } from '@charmverse/core/log';
 import type { BuilderNftType } from '@charmverse/core/prisma';
 import { ChainId } from '@decent.xyz/box-common';
 import { BoxHooksContextProvider } from '@decent.xyz/box-hooks';
@@ -32,6 +31,7 @@ import {
 } from '@packages/scoutgame/builderNfts/constants';
 import { purchaseWithPointsAction } from '@packages/scoutgame/builderNfts/purchaseWithPointsAction';
 import { convertCostToPoints } from '@packages/scoutgame/builderNfts/utils';
+import { currentSeason } from '@packages/scoutgame/dates';
 import { scoutgameMintsLogger } from '@packages/scoutgame/loggers/mintsLogger';
 import { calculateRewardForScout } from '@packages/scoutgame/points/dividePointsBetweenBuilderAndScouts';
 import type { MinimalUserInfo } from '@packages/scoutgame/users/interfaces';
@@ -42,6 +42,8 @@ import { useAction } from 'next-safe-action/hooks';
 import { useCallback, useEffect, useState } from 'react';
 import type { Address } from 'viem';
 import { useAccount, useSwitchChain } from 'wagmi';
+
+import { useTrackEvent } from 'hooks/useTrackEvent';
 
 import { useUserWalletAddress } from '../../../../hooks/api/session';
 import { usePurchase } from '../../../../providers/PurchaseProvider';
@@ -97,6 +99,7 @@ export function NFTPurchaseFormContent({ builder }: NFTPurchaseProps) {
   const { isExecutingTransaction, sendNftMintTransaction, isSavingDecentTransaction, purchaseSuccess, purchaseError } =
     usePurchase();
   const { showMessage } = useSnackbar();
+  const trackEvent = useTrackEvent();
 
   const { switchChainAsync } = useSwitchChain();
   const { data: nftStats } = useGetBuilderNftStats({ builderId });
@@ -296,6 +299,14 @@ export function NFTPurchaseFormContent({ builder }: NFTPurchaseProps) {
         );
       });
     }
+
+    trackEvent('nft_purchase', {
+      amount: tokensToBuy,
+      paidWithPoints: paymentMethod === 'points',
+      builderPath: builder.path,
+      season: currentSeason,
+      nftType: builder.nftType
+    });
   };
 
   const isLoading =

--- a/packages/scoutgame-ui/src/components/common/WarpcastLogin/WarpcastLogin.tsx
+++ b/packages/scoutgame-ui/src/components/common/WarpcastLogin/WarpcastLogin.tsx
@@ -3,7 +3,8 @@
 import { AuthKitProvider } from '@farcaster/auth-kit';
 import { Link, Typography } from '@mui/material';
 import { getAuthConfig } from '@packages/scoutgame/farcaster/config';
-import { useTrackEvent } from '@packages/scoutgame-ui/hooks/useTrackEvent';
+
+import { useTrackEvent } from '../../../hooks/useTrackEvent';
 
 import { WarpcastLoginButton } from './WarpcastLoginButton';
 

--- a/packages/scoutgame-ui/src/hooks/useTrackEvent.ts
+++ b/packages/scoutgame-ui/src/hooks/useTrackEvent.ts
@@ -7,7 +7,7 @@ export function useTrackEvent() {
   const { execute } = useAction(trackEventAction);
 
   return useCallback(
-    function trackEvent(event: MixpanelEventName, properties?: Record<string, string | number>) {
+    function trackEvent(event: MixpanelEventName, properties?: Record<string, string | number | boolean>) {
       execute({
         event,
         currentPageTitle: document.title,

--- a/packages/scoutgame/src/builderNfts/__tests__/recordNftMint.spec.ts
+++ b/packages/scoutgame/src/builderNfts/__tests__/recordNftMint.spec.ts
@@ -20,16 +20,11 @@ jest.unstable_mockModule('../clients/builderContractReadClient', () => ({
   }
 }));
 
-jest.unstable_mockModule('@packages/mixpanel/trackUserAction', () => ({
-  trackUserAction: jest.fn()
-}));
-
 jest.unstable_mockModule('@packages/scoutgame/builderNfts/refreshBuilderNftPrice', () => ({
   refreshBuilderNftPrice: jest.fn()
 }));
 
 const { recordNftMint } = await import('../recordNftMint');
-const { trackUserAction } = await import('@packages/mixpanel/trackUserAction');
 const { refreshBuilderNftPrice } = await import('@packages/scoutgame/builderNfts/refreshBuilderNftPrice');
 
 describe('recordNftMint', () => {
@@ -89,15 +84,6 @@ describe('recordNftMint', () => {
 
     expect(scoutStats?.nftsPurchased).toBe(amount);
 
-    expect(trackUserAction).toHaveBeenCalledWith('nft_purchase', {
-      userId: builderNft.builderId,
-      amount,
-      builderPath: builder.path,
-      paidWithPoints: true,
-      nftType: builderNft.nftType,
-      season: builderNft.season
-    });
-
     expect(refreshBuilderNftPrice).toHaveBeenCalledWith({
       builderId: builder.id,
       season: builderNft.season
@@ -121,8 +107,6 @@ describe('recordNftMint', () => {
       paidWithPoints: true,
       skipMixpanel: true
     });
-
-    expect(trackUserAction).not.toHaveBeenCalled();
   });
 
   it('should skip price refresh if this flag is provided', async () => {

--- a/packages/scoutgame/src/builderNfts/recordNftMint.ts
+++ b/packages/scoutgame/src/builderNfts/recordNftMint.ts
@@ -2,7 +2,6 @@ import { InvalidInputError } from '@charmverse/core/errors';
 import { log } from '@charmverse/core/log';
 import type { NFTPurchaseEvent } from '@charmverse/core/prisma-client';
 import { prisma } from '@charmverse/core/prisma-client';
-import { trackUserAction } from '@packages/mixpanel/trackUserAction';
 import { refreshBuilderNftPrice } from '@packages/scoutgame/builderNfts/refreshBuilderNftPrice';
 import type { Season } from '@packages/scoutgame/dates';
 import { getCurrentWeek } from '@packages/scoutgame/dates';
@@ -200,17 +199,6 @@ export async function recordNftMint(
     amount,
     userId: scoutId
   });
-
-  if (!skipMixpanel) {
-    trackUserAction('nft_purchase', {
-      userId: builderNft.builderId,
-      amount,
-      paidWithPoints,
-      builderPath: builderNft.builder.path!,
-      season: builderNft.season,
-      nftType: builderNft.nftType
-    });
-  }
 
   if (!skipPriceRefresh) {
     await refreshBuilderNftPrice({


### PR DESCRIPTION
We saw that cron was trying to access the platform var, which it shouldn't. I am guessing it's related to the NFT events which get picked up by cron sometimes

1) add 'cron' as a platform, this would help identify where it is being called from (i think it is mixpanel but not sure). its better than just logging it as a warning in this case
2) move the mixpanel event to the React components. The NFT may fail but from a user activity perspective it doesnt matter IMO