### PR TITLE
fix clicking links in account menu

### DIFF
--- a/packages/scoutgame-ui/src/components/common/Navigation/Header.tsx
+++ b/packages/scoutgame-ui/src/components/common/Navigation/Header.tsx
@@ -138,11 +138,11 @@ export function Header() {
                       onClose={handleCloseUserMenu}
                       onClick={handleCloseUserMenu}
                     >
-                      <MenuItem data-test='user-profile-button'>
-                        <Link href='/profile'>{user.displayName}</Link>
+                      <MenuItem component={Link} href='/profile' data-test='user-profile-button'>
+                        {user.displayName}
                       </MenuItem>
-                      <MenuItem>
-                        <Link href='/accounts'>Accounts</Link>
+                      <MenuItem component={Link} href='/accounts'>
+                        Accounts
                       </MenuItem>
                       {platform === 'webapp' && (
                         <MenuItem onClick={() => logoutUser()} data-test='sign-out-button'>


### PR DESCRIPTION
You have to click exactly on the user name to view profile right now and i was thinking that the page just took a while to load or something

![image](https://github.com/user-attachments/assets/7122eed0-bff1-436e-b732-96c44e230f3b)
