### PR TITLE
Delete beehiv loops

### DIFF
--- a/apps/cron/cron.yml
+++ b/apps/cron/cron.yml
@@ -15,8 +15,9 @@ cron:
     # Every 5 minutes
     schedule: '*/5 * * * *'
 
-  - name: 'update-mixpanel-user-profiles'
-    url: '/update-mixpanel-user-profiles'
+  # Sync external user profiles (Loops, Beehiiv, etc.)
+  - name: 'sync-external-user-profiles'
+    url: '/sync-external-user-profiles'
     # Run once an hour
     schedule: '0 * * * *'
 

--- a/apps/cron/src/tasks/processNftMints/index.ts
+++ b/apps/cron/src/tasks/processNftMints/index.ts
@@ -39,7 +39,11 @@ export async function processNftMints() {
 
       scoutgameMintsLogger.info(`Processed ${i + 1}/${totalPendingTxs} pending txs`);
     } catch (error) {
-      scoutgameMintsLogger.warn(`Error processing pending tx`, { pendingTransactionId: pendingTx.id, error });
+      scoutgameMintsLogger.warn(`Error processing pending tx`, {
+        pendingTransactionId: pendingTx.id,
+        userId: pendingTx.userId,
+        error
+      });
     }
   }
 }

--- a/apps/cron/src/tasks/syncExternalUserProfiles/deleteExternalProfiles.ts
+++ b/apps/cron/src/tasks/syncExternalUserProfiles/deleteExternalProfiles.ts
@@ -1,0 +1,20 @@
+import { log } from '@charmverse/core/log';
+import { deleteSubscriptionByEmail as deleteBeehiivSubscription } from '@packages/beehiiv/deleteSubscriptionByEmail';
+import { deleteContact as deleteLoopsContact } from '@packages/loops/client';
+import { deleteMixpanelProfiles } from '@packages/mixpanel/deleteUserProfiles';
+import { DateTime } from 'luxon';
+
+export async function deleteExternalProfiles(users: { id: string; email: string | null }[]) {
+  await deleteMixpanelProfiles(users);
+  log.info(`Deleted ${users.length} profiles from Mixpanel`);
+
+  // Delete from email subscriptions
+  const deletedRecentlyWithEmail = users.filter((user) => user.email);
+  if (deletedRecentlyWithEmail.length > 0) {
+    for (const user of deletedRecentlyWithEmail) {
+      await deleteLoopsContact({ email: user.email! });
+      await deleteBeehiivSubscription({ email: user.email! });
+    }
+    log.info(`Deleted ${deletedRecentlyWithEmail.length} profiles from Loops.so and Beehiiv`);
+  }
+}

--- a/apps/cron/src/tasks/syncExternalUserProfiles/deleteExternalProfiles.ts
+++ b/apps/cron/src/tasks/syncExternalUserProfiles/deleteExternalProfiles.ts
@@ -2,7 +2,6 @@ import { log } from '@charmverse/core/log';
 import { deleteSubscriptionByEmail as deleteBeehiivSubscription } from '@packages/beehiiv/deleteSubscriptionByEmail';
 import { deleteContact as deleteLoopsContact } from '@packages/loops/client';
 import { deleteMixpanelProfiles } from '@packages/mixpanel/deleteUserProfiles';
-import { DateTime } from 'luxon';
 
 export async function deleteExternalProfiles(users: { id: string; email: string | null }[]) {
   await deleteMixpanelProfiles(users);

--- a/apps/cron/src/worker.ts
+++ b/apps/cron/src/worker.ts
@@ -12,8 +12,8 @@ import { sendNotifications } from './tasks/pushNotifications/sendNotifications';
 import { refreshShareImagesTask } from './tasks/refreshShareImages';
 import { resolveBalanceIssues } from './tasks/resolveBalanceIssues/resolveBalanceIssues';
 import { resolveMissingPurchasesTask } from './tasks/resolveMissingPurchases';
+import { syncExternalUserProfilesTask } from './tasks/syncExternalUserProfiles/syncExternalUserProfilesTask';
 import { updateAllBuilderCardActivities } from './tasks/updateBuilderCardActivity';
-import { updateMixpanelUserProfilesTask } from './tasks/updateMixpanelProfilesTask';
 import { updateTalentMoxieProfiles } from './tasks/updateTalentMoxieProfiles';
 
 const app = new Koa();
@@ -58,7 +58,7 @@ addTask('/process-gems-payout', processGemsPayout);
 
 addTask('/process-nft-mints', processNftMints);
 
-addTask('/update-mixpanel-user-profiles', updateMixpanelUserProfilesTask);
+addTask('/sync-external-user-profiles', syncExternalUserProfilesTask);
 
 addTask('/alert-low-wallet-gas-balance', alertLowWalletGasBalance);
 


### PR DESCRIPTION
When removing deleted users we should remove them from loops and beehiiv as well, so I repurposed the mixpanel task to be a job for any external profiles.

This PR also makes it so we only look back 2 hours. The job runs once an hour so that should be plenty of time to check.