### PR TITLE
fix bonus partner export

### DIFF
--- a/apps/admin/tsconfig.json
+++ b/apps/admin/tsconfig.json
@@ -26,20 +26,7 @@
       "hooks/*": ["./hooks/*"],
       "lib/*": ["./lib/*"],
       "public/*": ["./public/*"],
-      "theme/*": ["./theme/*"],
-      "@charmverse/core/prisma": ["../../node_modules/@charmverse/core/dist/cjs/prisma"],
-      "@charmverse/core/prisma-client": ["../../node_modules/@charmverse/core/dist/cjs/prisma-client"],
-      "@charmverse/core/shared": ["../../node_modules/@charmverse/core/dist/cjs/shared"],
-      "@charmverse/core/log": ["../../node_modules/@charmverse/core/dist/cjs/lib/log"],
-      "@charmverse/core/test": ["../../node_modules/@charmverse/core/dist/cjs/test"],
-      "@charmverse/core/permissions": ["../../node_modules/@charmverse/core/dist/cjs/permissions"],
-      "@charmverse/core/permissions/flags": ["../../node_modules/@charmverse/core/dist/cjs/permissions-flags"],
-      "@charmverse/core/pages": ["../../node_modules/@charmverse/core/dist/cjs/pages"],
-      "@charmverse/core/pages/utilities": ["../../node_modules/@charmverse/core/dist/cjs/pages-utilities"],
-      "@charmverse/core/proposals": ["../../node_modules/@charmverse/core/dist/cjs/proposals"],
-      "@charmverse/core/bounties": ["../../node_modules/@charmverse/core/dist/cjs/bounties"],
-      "@charmverse/core/utilities": ["../../node_modules/@charmverse/core/dist/cjs/utilities"],
-      "@charmverse/core/errors": ["../../node_modules/@charmverse/core/dist/cjs/errors"]
+      "theme/*": ["./theme/*"]
     }
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],


### PR DESCRIPTION
we're changing the rules so that partner and builder rewards will count all PRs, not just the first one that day. Removing the dependency of builder events in partner exports is a workaround for now, since i did not want to create builder events for previous weeks