### PR TITLE
fix test for quests

### DIFF
--- a/packages/scoutgame/src/quests/__tests__/getQuests.spec.ts
+++ b/packages/scoutgame/src/quests/__tests__/getQuests.spec.ts
@@ -73,6 +73,14 @@ describe('getQuests', () => {
     });
 
     await mockNFTPurchaseEvent({
+      builderId: builders[1].id,
+      scoutId: scout.id,
+      season: currentSeason,
+      week: currentSeason,
+      nftType: 'default'
+    });
+
+    await mockNFTPurchaseEvent({
       builderId: builders[0].id,
       scoutId: scout.id,
       season: currentSeason,


### PR DESCRIPTION
the test was working due to a bug, where we counted starter pack NFT towards your 5 builder nfts. This was fixed earlier today https://github.com/scoutgame/scoutgame.xyz/pull/257/files