### PR TITLE
Fixed issue with referral champion logic

### DIFF
--- a/packages/scoutgame/src/points/getPointStatsFromHistory.ts
+++ b/packages/scoutgame/src/points/getPointStatsFromHistory.ts
@@ -110,7 +110,7 @@ export async function getPointStatsFromHistory({
         recipientId: userId,
         event: {
           type: {
-            in: ['misc_event', 'daily_claim', 'social_quest', 'daily_claim_streak', 'referral']
+            in: ['misc_event', 'daily_claim', 'social_quest', 'daily_claim_streak', 'referral', 'referral_bonus']
           }
         }
       }

--- a/packages/scoutgame/src/topConnector/getTopConnectors.ts
+++ b/packages/scoutgame/src/topConnector/getTopConnectors.ts
@@ -69,6 +69,7 @@ export async function getTopConnectorsOfTheDay(options?: { date?: DateTime }) {
         receipt,
         createdAt: receipt.createdAt
       }))
+      // Only include the referrers as only they can be referral champions
       .filter((event) => event.builder.id === event.receipt.recipientId)
   );
 }

--- a/packages/scoutgame/src/topConnector/getTopConnectors.ts
+++ b/packages/scoutgame/src/topConnector/getTopConnectors.ts
@@ -125,6 +125,7 @@ export async function getTopConnectorOfTheDay(options?: { date?: DateTime }) {
       },
       builder: {
         select: {
+          id: true,
           avatar: true,
           displayName: true,
           path: true,
@@ -145,11 +146,16 @@ export async function getTopConnectorOfTheDay(options?: { date?: DateTime }) {
   });
 
   const sortedByBuilder = groupBuilderEvents(
-    allBuilderEvents.map((events) => ({
-      builder: events.builder,
-      receipt: events.pointsReceipts[0],
-      createdAt: events.createdAt
-    }))
+    allBuilderEvents
+      .flatMap((event) =>
+        event.pointsReceipts.map((receipt) => ({
+          builder: event.builder,
+          receipt,
+          createdAt: event.createdAt
+        }))
+      )
+      // Only include the referrers as only they can be referral champions
+      .filter((event) => event.builder.id === event.receipt.recipientId)
   );
 
   return sortedByBuilder.at(0);


### PR DESCRIPTION
Referral champion export showed the user won 40 and 60 points for the day. That is not in multiple of 50. It happened because we looped through the events and not the point receipts. Events are created as soon as a new referee is onboarded, but the points receipts are created when the referee scouts a builder which might differ from the referrer onboarded time.