### PR TITLE
better cursor UX for scout table headers

### DIFF
--- a/packages/scoutgame-ui/src/components/scout/ScoutPageTable/components/BuildersTable.tsx
+++ b/packages/scoutgame-ui/src/components/scout/ScoutPageTable/components/BuildersTable.tsx
@@ -67,7 +67,7 @@ export function BuildersTable({
           backgroundColor: 'background.paper'
         }}
       >
-        <CommonTableRow>
+        <CommonTableRow sx={{ cursor: 'auto' }}>
           <TableCell align='left' sx={{ fontSize: { xs: '10px', md: 'initial' }, py: 1 }}>
             DEVELOPER
           </TableCell>

--- a/packages/scoutgame-ui/src/components/scout/ScoutPageTable/components/NewScoutsTable.tsx
+++ b/packages/scoutgame-ui/src/components/scout/ScoutPageTable/components/NewScoutsTable.tsx
@@ -42,7 +42,7 @@ export function NewScoutsTable({ scouts }: { scouts: NewScout[] }) {
             backgroundColor: 'background.paper'
           }}
         >
-          <CommonTableRow>
+          <CommonTableRow sx={{ cursor: 'auto' }}>
             <TableCell align='center'>RANK</TableCell>
             <TableCell align='left'>SCOUT</TableCell>
             <TableCell align='center' sx={{ display: { xs: 'none', md: 'table-cell' } }}>

--- a/packages/scoutgame-ui/src/components/scout/ScoutPageTable/components/ScoutsTable.tsx
+++ b/packages/scoutgame-ui/src/components/scout/ScoutPageTable/components/ScoutsTable.tsx
@@ -53,7 +53,7 @@ export function ScoutsTable({ scouts, order, sort }: { scouts: ScoutInfo[]; orde
           backgroundColor: 'background.paper'
         }}
       >
-        <CommonTableRow>
+        <CommonTableRow sx={{ cursor: 'auto' }}>
           <TableCell align='left' sx={{ fontSize: { xs: '10px', md: 'initial' }, py: 1 }}>
             SCOUT
           </TableCell>

--- a/packages/scoutgame/src/builders/getBuilders.ts
+++ b/packages/scoutgame/src/builders/getBuilders.ts
@@ -372,7 +372,7 @@ export async function getBuilders({
     }));
   }
 
-  log.error(`Invalid sortBy provided: ${sortBy}`);
+  log.error(`Invalid sortBy provided for getBuilders: ${sortBy}`);
 
   return [];
 }

--- a/packages/scoutgame/src/scouts/getScouts.ts
+++ b/packages/scoutgame/src/scouts/getScouts.ts
@@ -180,6 +180,6 @@ export async function getScouts({
     }
   }
 
-  log.error(`Invalid sortBy provided: ${sortBy}`);
+  log.error(`Invalid sortBy provided for getScouts: ${sortBy}`);
   return [];
 }


### PR DESCRIPTION
only turn the mouse into a pointer on columns that can be sorted