### PR TITLE
dont log daily claim being already claimed as an error

### DIFF
--- a/packages/scoutgame/src/claims/claimDailyReward.ts
+++ b/packages/scoutgame/src/claims/claimDailyReward.ts
@@ -70,23 +70,22 @@ export async function claimDailyReward({
     });
 
     if (existingEvent) {
-      log.warn('Daily reward already claimed', {
+      log.debug('Daily reward already claimed', {
         userId,
         week,
         dayOfWeek
       });
-      throw new Error('Daily reward already claimed');
+    } else {
+      await sendPointsForDailyClaim({
+        builderId: userId,
+        dayOfWeek,
+        week,
+        points
+      });
+      trackUserAction('daily_claim', {
+        userId
+      });
     }
-
-    await sendPointsForDailyClaim({
-      builderId: userId,
-      dayOfWeek,
-      week,
-      points
-    });
-    trackUserAction('daily_claim', {
-      userId
-    });
   }
 
   return { points };


### PR DESCRIPTION
FWIW i think someone is botting the API to get daily claims because we are getting 10-20 requests all at the same time. i dont think we really care, at least while it is just points, but regardless i dont think it should be an error.