### PR TITLE
Fixed daily claims streak points display

### DIFF
--- a/packages/scoutgame/src/claims/getDailyClaims.ts
+++ b/packages/scoutgame/src/claims/getDailyClaims.ts
@@ -18,9 +18,10 @@ export async function getDailyClaims(userId: string): Promise<DailyClaim[]> {
     orderBy: {
       dayOfWeek: 'asc'
     },
-    include: {
+    select: {
+      dayOfWeek: true,
       event: {
-        include: {
+        select: {
           pointsReceipts: true
         }
       }
@@ -31,6 +32,13 @@ export async function getDailyClaims(userId: string): Promise<DailyClaim[]> {
     where: {
       userId,
       week: currentWeek
+    },
+    select: {
+      event: {
+        select: {
+          pointsReceipts: true
+        }
+      }
     }
   });
 
@@ -39,6 +47,7 @@ export async function getDailyClaims(userId: string): Promise<DailyClaim[]> {
     .map((_, index) => {
       const dailyClaimEvent = dailyClaimEvents.find((_dailyClaimEvent) => _dailyClaimEvent.dayOfWeek === index + 1);
       const points = dailyClaimEvent?.event?.pointsReceipts[0]?.value || 0;
+      const streakPoints = dailyClaimStreakEvent?.event?.pointsReceipts[0]?.value || 0;
 
       const dailyClaimInfo = {
         day: index + 1,
@@ -49,7 +58,10 @@ export async function getDailyClaims(userId: string): Promise<DailyClaim[]> {
 
       // For the last day of the week, return 2 claims: one for the daily claim and one for the bonus claim
       if (index === 6) {
-        return [dailyClaimInfo, { ...dailyClaimInfo, claimed: !!dailyClaimStreakEvent, isBonus: true }];
+        return [
+          dailyClaimInfo,
+          { ...dailyClaimInfo, points: streakPoints, claimed: !!dailyClaimStreakEvent, isBonus: true }
+        ];
       }
 
       return [dailyClaimInfo];


### PR DESCRIPTION
Daily claim streak points are not shown correctly, it shows the day's regular points

Before fix:
<img width="471" alt="image" src="https://github.com/user-attachments/assets/06775043-1e11-4760-8e3a-b77f1974c03d" />

After fix:
<img width="462" alt="image" src="https://github.com/user-attachments/assets/ee76534e-4886-4f0e-a68d-4b5f47c4473e" />
