### PR TITLE
Make claiming points available before sending notifications

### DIFF
--- a/apps/cron/src/tasks/processGemsPayout/index.ts
+++ b/apps/cron/src/tasks/processGemsPayout/index.ts
@@ -77,8 +77,6 @@ export async function processGemsPayout(ctx: Context, { now = DateTime.utc() }: 
     })
   ]);
 
-  const notificationsSent = await sendGemsPayoutNotifications({ week });
-
   await prisma.weeklyClaims.upsert({
     where: {
       week
@@ -93,6 +91,8 @@ export async function processGemsPayout(ctx: Context, { now = DateTime.utc() }: 
     },
     update: {}
   });
+
+  const notificationsSent = await sendGemsPayoutNotifications({ week });
 
   log.info(`Processed ${topWeeklyBuilders.length} builders points payout`, { notificationsSent });
 }


### PR DESCRIPTION
Due to the large number of farcaster users and scouts it takes a lot of time for the notifications to be sent. We should make the claim available as soon as well it is available. Otherwise they might get a notification but won't be able to claim anything since the weekly points would still be processing