### PR TITLE
DX for Dev/test env: destroy sessions from bad data

### DIFF
--- a/packages/scoutgame-router/api/session/user/route.ts
+++ b/packages/scoutgame-router/api/session/user/route.ts
@@ -1,5 +1,7 @@
+import { log } from '@charmverse/core/log';
 import { getSession } from '@packages/nextjs/session/getSession';
 import { getUserFromSession } from '@packages/nextjs/session/getUserFromSession';
+import { isDevEnv, isTestEnv } from '@packages/utils/constants';
 import { NextResponse } from 'next/server';
 
 // This API Route is non-blocking and called on every page load. Use it to refresh things about the current user
@@ -10,6 +12,11 @@ export async function GET() {
     // Logout the user if they have been deleted
     session.destroy();
     return NextResponse.json(null);
+  }
+  if ((isDevEnv || isTestEnv) && user === null && (session.scoutId || session.adminId)) {
+    log.warn('Destroying session: user is null but session has scoutId or adminId');
+    session.destroy();
+    return NextResponse.json(user);
   }
   return NextResponse.json(user);
 }


### PR DESCRIPTION
PROBLEM:
When switching databases or working in test/dev, I often have an old session pointing to a user that doesn't exist. I have to go delete the cookie in order to access the login page.

SOLUTION:
the app automatically detects this scenario and just resets the session