### PR TITLE
fix some errors in cron

### DIFF
--- a/apps/cron/cron.yml
+++ b/apps/cron/cron.yml
@@ -58,5 +58,5 @@ cron:
 
   - name: 'process-dune-analytics'
     url: '/process-dune-analytics'
-    # every hour
-    schedule: '0 * * * *'
+    # once a day at midnight
+    schedule: '0 0 * * *'

--- a/apps/cron/src/tasks/processBuilderActivity/index.ts
+++ b/apps/cron/src/tasks/processBuilderActivity/index.ts
@@ -81,6 +81,8 @@ export async function processAllBuilderActivity(
       githubUser: builder.githubUsers[0]!,
       createdAfter: newBuilder ? getDateFromISOWeek(getCurrentWeek()).toJSDate() : createdAfter,
       season
+    }).catch((error) => {
+      log.error('Error processing builder activity', { error, userId: builder.id });
     });
 
     if (builders.indexOf(builder) % 10 === 0) {

--- a/packages/github/src/client.ts
+++ b/packages/github/src/client.ts
@@ -12,12 +12,12 @@ export const octokit = new OctokitWithThrottling({
   throttle: {
     // @ts-ignore
     onRateLimit: (retryAfter, options, _octokit, retryCount) => {
-      if (retryCount < 2) {
-        log.debug(`[Octokit] Retrying after ${retryAfter} seconds!`);
-        // only retries twice
-        return true;
-      }
-      return false;
+      log.info(`[Octokit] Retrying after ${retryAfter} seconds! Retry count: ${retryCount}`);
+      return true;
+      // if (retryCount < 2) {
+      //   // only retries twice
+      //   return true;
+      // }
     },
     // @ts-ignore
     onSecondaryRateLimit: (retryAfter, options, _octokit) => {


### PR DESCRIPTION
- use one global client for all github clients (since it manages throttling internally, should reduce rate limit errors)
- reduce dune analytics to once per day. even this is not enough to support many wallets:
 
we hit our monthly credit limit of 2500 with Dune (I didn't see this limitation til now)
With just 3 wallets, running once an hour we hit the limit in less than 3 days. So free tier gives us about 143 requests for free per month
The bad news is that the first paid tier is not much better, 4000 credits per month. For $349/mo we can get 25k credits: https://dune.com/pricing 
