### PR TITLE
remove redundant card count

### DIFF
--- a/apps/scoutgame/app/(general)/u/[path]/page.tsx
+++ b/apps/scoutgame/app/(general)/u/[path]/page.tsx
@@ -43,7 +43,7 @@ export default async function Profile({ params, searchParams }: Props) {
   const user = await getUserByPathCached(params.path);
   const tab = searchParams.tab || (user?.builderStatus === 'approved' ? 'builder' : 'scout');
   const session = await getSession();
-  const scoutId = session?.scoutId;
+  const loggedInUserId = session?.scoutId;
 
   if (!user || typeof tab !== 'string') {
     return notFound();
@@ -55,7 +55,7 @@ export default async function Profile({ params, searchParams }: Props) {
     <>
       <FarcasterMetadata user={user} />
       <PageContainer>
-        <PublicProfilePage scoutId={scoutId} user={user} tab={tab} scoutProjects={scoutProjects} />
+        <PublicProfilePage loggedInUserId={loggedInUserId} user={user} tab={tab} scoutProjects={scoutProjects} />
       </PageContainer>
     </>
   );

--- a/packages/scoutgame-ui/src/components/[path]/PublicProfilePage.tsx
+++ b/packages/scoutgame-ui/src/components/[path]/PublicProfilePage.tsx
@@ -1,6 +1,6 @@
 import 'server-only';
 
-import { BuilderNftType, type BuilderStatus } from '@charmverse/core/prisma-client';
+import type { BuilderStatus } from '@charmverse/core/prisma';
 import { Box, Stack, Paper } from '@mui/material';
 import type { ScoutProjectMinimal } from '@packages/scoutgame/projects/getUserScoutProjects';
 import type { BasicUserInfo } from '@packages/users/interfaces';
@@ -17,12 +17,12 @@ import { PublicProfileTabsMenu } from './PublicProfileTabsMenu';
 type UserProfile = BasicUserInfo & { displayName: string; builderStatus: BuilderStatus | null };
 
 export function PublicProfilePage({
-  scoutId,
+  loggedInUserId,
   user,
   tab,
   scoutProjects
 }: {
-  scoutId?: string;
+  loggedInUserId?: string;
   user: UserProfile;
   tab: string;
   scoutProjects?: ScoutProjectMinimal[];
@@ -54,9 +54,9 @@ export function PublicProfilePage({
         />
       </Box>
       {tab === 'builder' ? (
-        <PublicBuilderProfile scoutId={scoutId} builder={user} scoutProjects={scoutProjects} />
+        <PublicBuilderProfile loggedInUserId={loggedInUserId} builder={user} scoutProjects={scoutProjects} />
       ) : (
-        <PublicScoutProfile publicUser={user} scoutProjects={scoutProjects} />
+        <PublicScoutProfile loggedInUserId={loggedInUserId} publicUser={user} scoutProjects={scoutProjects} />
       )}
     </Box>
   );

--- a/packages/scoutgame-ui/src/components/[path]/components/PublicBuilderProfile/PublicBuilderProfile.tsx
+++ b/packages/scoutgame-ui/src/components/[path]/components/PublicBuilderProfile/PublicBuilderProfile.tsx
@@ -13,11 +13,11 @@ import { PublicBuilderProfileContainer } from './PublicBuilderProfileContainer';
 
 export async function PublicBuilderProfile({
   builder,
-  scoutId,
+  loggedInUserId,
   scoutProjects
 }: {
-  builder: BuilderProfileProps['builder'];
-  scoutId?: string;
+  builder: Omit<BuilderProfileProps['builder'], 'nftsSoldToLoggedInScout' | 'starterNftSoldToLoggedInScout'>;
+  loggedInUserId?: string;
   scoutProjects?: ScoutProjectMinimal[];
 }) {
   const builderId = builder.id;
@@ -28,7 +28,7 @@ export async function PublicBuilderProfile({
     { allTimePoints = 0, seasonPoints = 0, rank = 0, gemsCollected = 0 },
     builderActivities,
     { scouts = [], totalNftsSold = 0, totalScouts = 0 },
-    { level, estimatedPayout, last14DaysRank, nftsSoldToScout, starterPackSoldToScout },
+    { level, estimatedPayout, last14DaysRank, nftsSoldToLoggedInScout, starterNftSoldToLoggedInScout },
     { remaining: remainingStarterCards }
   ] = await Promise.all([
     getBuilderNft(builderId),
@@ -36,8 +36,8 @@ export async function PublicBuilderProfile({
     getBuilderStats(builderId),
     getBuilderActivities({ builderId, limit: 200 }),
     getBuilderScouts(builderId),
-    getBuilderCardStats({ builderId, scoutId }),
-    countStarterPackTokensPurchased(scoutId)
+    getBuilderCardStats({ builderId, loggedInScoutId: loggedInUserId }),
+    countStarterPackTokensPurchased(loggedInUserId)
   ]);
 
   return (
@@ -46,12 +46,12 @@ export async function PublicBuilderProfile({
       builder={{
         ...builder,
         gemsCollected,
-        nftsSoldToScout,
+        nftsSoldToLoggedInScout,
         last14DaysRank: last14DaysRank ?? [],
         level: level ?? 0,
         estimatedPayout: estimatedPayout ?? 0
       }}
-      starterPackSoldToScout={starterPackSoldToScout}
+      starterNftSoldToLoggedInScout={starterNftSoldToLoggedInScout}
       defaultNft={defaultNft}
       starterPackNft={remainingStarterCards > 0 ? starterPackNft : null}
       allTimePoints={allTimePoints}

--- a/packages/scoutgame-ui/src/components/[path]/components/PublicBuilderProfile/PublicBuilderProfileContainer.tsx
+++ b/packages/scoutgame-ui/src/components/[path]/components/PublicBuilderProfile/PublicBuilderProfileContainer.tsx
@@ -24,7 +24,7 @@ import { PublicBuilderStats } from './PublicBuilderStats';
 export type BuilderProfileProps = {
   builder: BasicUserInfo & {
     builderStatus: BuilderStatus | null;
-  } & Omit<BuilderCardStats, 'starterPackSoldToScout'>;
+  } & Omit<BuilderCardStats, 'starterNftSoldToLoggedInScout'>;
   defaultNft: {
     imageUrl: string;
     // TODO: use the currentPriceInScoutToken when we move to $SCOUT
@@ -36,7 +36,7 @@ export type BuilderProfileProps = {
   } | null;
   builderActivities: BuilderActivity[];
   scoutProjects?: ScoutProjectMinimal[];
-  starterPackSoldToScout: boolean;
+  starterNftSoldToLoggedInScout: boolean;
 } & BuilderStats &
   BuilderScouts;
 
@@ -69,7 +69,7 @@ export function PublicBuilderProfileContainer({
   gemsCollected,
   rank,
   scoutProjects,
-  starterPackSoldToScout
+  starterNftSoldToLoggedInScout
 }: BuilderProfileProps) {
   const isDesktop = useMdScreen();
   const isLgScreen = useLgScreen();
@@ -103,7 +103,7 @@ export function PublicBuilderProfileContainer({
                           price: starterPackNft.currentPrice
                         }}
                         showLabel
-                        markStarterCardPurchased={starterPackSoldToScout}
+                        markStarterCardPurchased={starterNftSoldToLoggedInScout}
                         type='starter_pack'
                       />
                     </Stack>
@@ -169,7 +169,7 @@ export function PublicBuilderProfileContainer({
                             price: starterPackNft.currentPrice
                           }}
                           showLabel
-                          markStarterCardPurchased={starterPackSoldToScout}
+                          markStarterCardPurchased={starterNftSoldToLoggedInScout}
                           type='starter_pack'
                         />
                       </Stack>

--- a/packages/scoutgame-ui/src/components/[path]/components/PublicScoutProfile/PublicScoutProfile.tsx
+++ b/packages/scoutgame-ui/src/components/[path]/components/PublicScoutProfile/PublicScoutProfile.tsx
@@ -13,15 +13,17 @@ import { PublicScoutProfileContainer } from './PublicScoutProfileContainer';
 
 export async function PublicScoutProfile({
   publicUser,
+  loggedInUserId,
   scoutProjects
 }: {
   publicUser: BasicUserInfo;
+  loggedInUserId?: string;
   scoutProjects?: ScoutProjectMinimal[];
 }) {
   const allPromises = [
     findScoutOrThrow(publicUser.id),
     getScoutStats(publicUser.id),
-    getScoutedBuilders({ scoutId: publicUser.id })
+    getScoutedBuilders({ scoutIdInView: publicUser.id, loggedInScoutId: loggedInUserId })
   ] as const;
   const [error, data] = await safeAwaitSSRData(Promise.all(allPromises));
 

--- a/packages/scoutgame-ui/src/components/[path]/components/PublicScoutProfile/PublicScoutProfileContainer.tsx
+++ b/packages/scoutgame-ui/src/components/[path]/components/PublicScoutProfile/PublicScoutProfileContainer.tsx
@@ -71,7 +71,7 @@ export function PublicScoutProfileContainer({
           Scouted Developers
         </Typography>
         {scoutedBuilders.length > 0 ? (
-          <BuildersGallery hideScoutCount builders={scoutedBuilders} columns={5} size={isDesktop ? 'large' : 'small'} />
+          <BuildersGallery builders={scoutedBuilders} columns={5} size={isDesktop ? 'large' : 'small'} />
         ) : (
           <Paper sx={{ p: 2 }}>
             <Typography>This Scout hasn't discovered any Developers yet. Check back to see who they find!</Typography>

--- a/packages/scoutgame-ui/src/components/common/Card/BuilderCard/BuilderCard.tsx
+++ b/packages/scoutgame-ui/src/components/common/Card/BuilderCard/BuilderCard.tsx
@@ -17,10 +17,8 @@ export function BuilderCard({
   size = 'medium',
   disableProfileUrl = false,
   markStarterCardPurchased = false,
-  type,
-  hideScoutCount = false
+  type
 }: {
-  hideScoutCount?: boolean;
   size?: 'x-small' | 'small' | 'medium' | 'large';
   builder: Omit<Partial<BuilderInfo>, RequiredBuilderInfoFields> & Pick<BuilderInfo, RequiredBuilderInfoFields>;
   hideDetails?: boolean;
@@ -52,12 +50,7 @@ export function BuilderCard({
         {builder.builderStatus === 'banned' ? (
           <Typography textAlign='center'>SUSPENDED</Typography>
         ) : hideDetails ? null : (
-          <BuilderCardStats
-            {...builder}
-            starterPack={type === 'starter_pack'}
-            size={size}
-            hideScoutCount={hideScoutCount}
-          />
+          <BuilderCardStats {...builder} starterPack={type === 'starter_pack'} size={size} />
         )}
       </BuilderCardNftDisplay>
       {typeof builder.price !== 'undefined' && showPurchaseButton && (

--- a/packages/scoutgame-ui/src/components/common/Card/BuilderCard/BuilderCardName.tsx
+++ b/packages/scoutgame-ui/src/components/common/Card/BuilderCard/BuilderCardName.tsx
@@ -11,11 +11,9 @@ export function BuilderCardName({
   name,
   size,
   starterPack,
-  nftsSoldToScout,
-  hideScoutCount = false
+  nftsSoldToLoggedInScout
 }: {
-  hideScoutCount?: boolean;
-  nftsSoldToScout?: number | null;
+  nftsSoldToLoggedInScout?: number | null;
   name: string;
   size: 'x-small' | 'small' | 'medium' | 'large';
   starterPack?: boolean;
@@ -25,7 +23,7 @@ export function BuilderCardName({
   const { fontSize, spanRef } = useDynamicFontSize(name, minFontSize, maxFontSize);
   const isMdScreen = useMdScreen();
   const isMounted = useIsMounted();
-  const showScoutCount = !hideScoutCount && nftsSoldToScout;
+  const showScoutCount = !!nftsSoldToLoggedInScout;
 
   if (!isMounted) {
     return null;
@@ -80,7 +78,7 @@ export function BuilderCardName({
                 fontSize
               }}
             >
-              {nftsSoldToScout}
+              {nftsSoldToLoggedInScout}
             </Typography>
             <Image
               width={isMdScreen ? 12.5 : 10}

--- a/packages/scoutgame-ui/src/components/common/Card/BuilderCard/BuilderCardStats.tsx
+++ b/packages/scoutgame-ui/src/components/common/Card/BuilderCard/BuilderCardStats.tsx
@@ -9,17 +9,15 @@ export function BuilderCardStats({
   size,
   gemsCollected,
   estimatedPayout,
-  nftsSoldToScout,
-  starterPack,
-  hideScoutCount = false
+  nftsSoldToLoggedInScout,
+  starterPack
 }: {
-  hideScoutCount?: boolean;
   gemsCollected?: number;
   displayName: string;
   last14DaysRank?: (number | null)[] | null;
   size: 'x-small' | 'small' | 'medium' | 'large';
   estimatedPayout?: number | null;
-  nftsSoldToScout?: number | null;
+  nftsSoldToLoggedInScout?: number | null;
   starterPack?: boolean;
 }) {
   return (
@@ -34,8 +32,7 @@ export function BuilderCardStats({
         name={displayName}
         size={size}
         starterPack={starterPack}
-        hideScoutCount={hideScoutCount}
-        nftsSoldToScout={nftsSoldToScout}
+        nftsSoldToLoggedInScout={nftsSoldToLoggedInScout}
       />
     </Stack>
   );

--- a/packages/scoutgame-ui/src/components/common/Gallery/BuildersGallery.tsx
+++ b/packages/scoutgame-ui/src/components/common/Gallery/BuildersGallery.tsx
@@ -7,14 +7,12 @@ export function BuildersGallery({
   builders,
   columns = 6,
   size = 'medium',
-  markStarterCardPurchased = false,
-  hideScoutCount = false
+  markStarterCardPurchased = false
 }: {
   builders: BuilderInfo[];
   columns?: number;
   size?: 'small' | 'medium' | 'large';
   markStarterCardPurchased?: boolean;
-  hideScoutCount?: boolean;
 }) {
   return (
     <Box sx={{ flexGrow: 1 }}>
@@ -26,13 +24,17 @@ export function BuildersGallery({
         {builders.map((builder) => (
           <Grid key={builder.path} size={{ xs: 1 }} display='flex' justifyContent='center' alignItems='center'>
             <Box>
+              {builder.nftsSoldToScoutInView !== undefined && builder.nftsSoldToScoutInView > 0 && (
+                <Typography color='green.main' textAlign='right' mb={1}>
+                  X {builder.nftsSoldToScoutInView}
+                </Typography>
+              )}
               <BuilderCard
                 builder={builder}
                 showPurchaseButton
                 size={size}
                 type={builder.nftType}
                 markStarterCardPurchased={markStarterCardPurchased}
-                hideScoutCount={hideScoutCount}
               />
             </Box>
           </Grid>

--- a/packages/scoutgame-ui/src/components/common/Gallery/BuildersGallery.tsx
+++ b/packages/scoutgame-ui/src/components/common/Gallery/BuildersGallery.tsx
@@ -26,11 +26,6 @@ export function BuildersGallery({
         {builders.map((builder) => (
           <Grid key={builder.path} size={{ xs: 1 }} display='flex' justifyContent='center' alignItems='center'>
             <Box>
-              {builder.nftsSoldToScout !== undefined && builder.nftsSoldToScout > 0 && (
-                <Typography color='green.main' textAlign='right' mb={1}>
-                  X {builder.nftsSoldToScout ?? 0}
-                </Typography>
-              )}
               <BuilderCard
                 builder={builder}
                 showPurchaseButton

--- a/packages/scoutgame-ui/src/components/profile/components/ScoutProfile/ScoutProfile.tsx
+++ b/packages/scoutgame-ui/src/components/profile/components/ScoutProfile/ScoutProfile.tsx
@@ -12,7 +12,7 @@ import { ScoutStats } from './ScoutStats';
 
 export async function ScoutProfile({ userId }: { userId: string }) {
   const [error, data] = await safeAwaitSSRData(
-    Promise.all([getUserSeasonStats(userId), getScoutedBuilders({ scoutId: userId })])
+    Promise.all([getUserSeasonStats(userId), getScoutedBuilders({ loggedInScoutId: userId, scoutIdInView: userId })])
   );
 
   if (error) {
@@ -21,7 +21,10 @@ export async function ScoutProfile({ userId }: { userId: string }) {
 
   const [seasonStats, scoutedBuilders] = data;
 
-  const nftsPurchasedThisSeason = scoutedBuilders.reduce((acc, builder) => acc + (builder.nftsSoldToScout || 0), 0);
+  const nftsPurchasedThisSeason = scoutedBuilders.reduce(
+    (acc, builder) => acc + (builder.nftsSoldToScoutInView || 0),
+    0
+  );
 
   return (
     <Stack gap={1}>

--- a/packages/scoutgame-ui/src/components/scout/ScoutPageTable/ScoutPageTable.tsx
+++ b/packages/scoutgame-ui/src/components/scout/ScoutPageTable/ScoutPageTable.tsx
@@ -22,7 +22,12 @@ export async function ScoutPageTable({
 }) {
   if (tab === 'builders') {
     const [, builders = []] = await safeAwaitSSRData(
-      getBuilders({ limit: 200, sortBy: sort as BuildersSortBy, order: order as 'asc' | 'desc', userId })
+      getBuilders({
+        limit: 200,
+        sortBy: sort as BuildersSortBy,
+        order: order as 'asc' | 'desc',
+        loggedInScoutId: userId
+      })
     );
     return <BuildersTable builders={builders} order={order ?? 'desc'} sort={(sort as BuildersSortBy) ?? 'week_gems'} />;
   } else if (tab === 'scouts') {

--- a/packages/scoutgame-ui/src/components/scout/ScoutPageTable/components/BuildersTable.tsx
+++ b/packages/scoutgame-ui/src/components/scout/ScoutPageTable/components/BuildersTable.tsx
@@ -158,10 +158,10 @@ export function BuildersTable({
               >
                 <Avatar src={builder.avatar} name={builder.displayName} size={isMdScreen ? 'medium' : 'xSmall'} />
                 <Stack maxWidth={{ xs: '50px', md: 'initial' }}>
-                  {builder.nftsSoldToScout ? (
+                  {builder.nftsSoldToLoggedInScout ? (
                     <Stack direction='row' alignItems='center' gap={0.5}>
                       <Typography fontSize={{ xs: '10.5px', md: '14px' }} color='green.main' noWrap>
-                        {builder.nftsSoldToScout}
+                        {builder.nftsSoldToLoggedInScout}
                       </Typography>
                       <Image
                         width={isMdScreen ? 15 : 13}

--- a/packages/scoutgame/src/builders/getBuilders.ts
+++ b/packages/scoutgame/src/builders/getBuilders.ts
@@ -114,7 +114,7 @@ export async function getBuilders({
       estimatedPayout: user.builderNfts[0]?.estimatedPayout || 0,
       last14DaysRank: normalizeLast14DaysRank(user.builderCardActivities[0]) || [],
       rank: user.userWeeklyStats[0]?.rank,
-      nftsSoldToLoggedInScout: user.builderNfts[0]?.nftOwners.reduce((acc, nft) => acc + nft.balance, 0)
+      nftsSoldToLoggedInScout: user.builderNfts[0]?.nftOwners?.reduce((acc, nft) => acc + nft.balance, 0)
     }));
   } else if (sortBy === 'estimated_payout') {
     const builderNfts = await prisma.builderNft.findMany({
@@ -342,7 +342,7 @@ export async function getBuilders({
       level: user.userSeasonStats[0]?.level || 0,
       estimatedPayout: user.builderNfts[0]?.estimatedPayout || 0,
       rank,
-      nftsSoldToLoggedInScout: user.builderNfts[0]?.nftOwners.reduce((acc, nft) => acc + nft.balance, 0) || null,
+      nftsSoldToLoggedInScout: user.builderNfts[0]?.nftOwners?.reduce((acc, nft) => acc + nft.balance, 0) || null,
       price: (user.builderNfts[0]?.currentPrice || 0) as bigint
     }));
   }

--- a/packages/scoutgame/src/builders/interfaces.ts
+++ b/packages/scoutgame/src/builders/interfaces.ts
@@ -17,7 +17,8 @@ export type BuilderMetrics = {
   estimatedPayout?: number | null;
   last14DaysRank?: (number | null)[] | null;
   gemsCollected?: number;
-  nftsSoldToScout?: number;
+  nftsSoldToLoggedInScout?: number;
+  nftsSoldToScoutInView?: number;
 };
 
 export type BuilderInfo = BasicUserInfo &

--- a/packages/scoutgame/src/scouts/getScoutedBuilders.ts
+++ b/packages/scoutgame/src/scouts/getScoutedBuilders.ts
@@ -244,34 +244,44 @@ export async function getScoutedBuilders({
     const nftsSoldToLoggedInScout = scoutedNfts
       .filter((s) => s.builderNft.builderId === builder.id && s.scoutWallet.scoutId === loggedInScoutId)
       .reduce((acc, nft) => acc + nft.balance, 0);
-    const nftsSoldToScoutInView =
-      loggedInScoutId === scoutIdInView
-        ? 0 // dont show this number if scout is looking at their own profile
-        : scoutedNfts
-            .filter((s) => s.builderNft.builderId === builder.id && s.scoutWallet.scoutId === scoutIdInView)
-            .reduce((acc, nft) => acc + nft.balance, 0);
-    if (nftsSoldToScoutInView === 0 && loggedInScoutId !== scoutIdInView) {
-      return [];
-    }
-    return builder.builderNfts.map((nft) => {
-      const nftData: BuilderInfo = {
-        id: builder.id,
-        nftImageUrl: nft.imageUrl,
-        path: builder.path,
-        displayName: builder.displayName,
-        builderStatus: builder.builderStatus!,
-        nftsSoldToScoutInView,
-        nftsSoldToLoggedInScout,
-        price: nft.currentPrice ?? 0,
-        last14DaysRank: normalizeLast14DaysRank(builder.builderCardActivities[0]),
-        nftType: nft.nftType,
-        gemsCollected: builder.userWeeklyStats[0]?.gemsCollected ?? 0,
-        congratsImageUrl: nft.congratsImageUrl,
-        estimatedPayout: nft.estimatedPayout ?? 0,
-        level: builder.userSeasonStats[0]?.level ?? 0
-      };
 
-      return nftData;
-    }) as BuilderInfo[];
+    return builder.builderNfts
+      .map((nft) => {
+        const nftsSoldToScoutInView =
+          loggedInScoutId === scoutIdInView
+            ? 0 // dont show this number if scout is looking at their own profile
+            : scoutedNfts
+                .filter(
+                  (s) =>
+                    s.builderNft.builderId === builder.id &&
+                    s.builderNft.nftType === nft.nftType &&
+                    s.scoutWallet.scoutId === scoutIdInView
+                )
+                .reduce((acc, _nft) => acc + _nft.balance, 0);
+
+        if (nftsSoldToScoutInView === 0 && loggedInScoutId !== scoutIdInView) {
+          return null;
+        }
+
+        const nftData: BuilderInfo = {
+          id: builder.id,
+          nftImageUrl: nft.imageUrl,
+          path: builder.path,
+          displayName: builder.displayName,
+          builderStatus: builder.builderStatus!,
+          nftsSoldToScoutInView,
+          nftsSoldToLoggedInScout,
+          price: nft.currentPrice ?? 0,
+          last14DaysRank: normalizeLast14DaysRank(builder.builderCardActivities[0]),
+          nftType: nft.nftType,
+          gemsCollected: builder.userWeeklyStats[0]?.gemsCollected ?? 0,
+          congratsImageUrl: nft.congratsImageUrl,
+          estimatedPayout: nft.estimatedPayout ?? 0,
+          level: builder.userSeasonStats[0]?.level ?? 0
+        };
+
+        return nftData;
+      })
+      .filter(isTruthy);
   });
 }

--- a/packages/scoutgame/src/scouts/getScoutedBuilders.ts
+++ b/packages/scoutgame/src/scouts/getScoutedBuilders.ts
@@ -3,46 +3,49 @@ import { prisma } from '@charmverse/core/prisma-client';
 import { getCurrentSeasonStart, getCurrentWeek } from '@packages/dates/utils';
 import { BasicUserInfoSelect } from '@packages/users/queries';
 import { getPlatform } from '@packages/utils/platform';
+import { isTruthy } from '@packages/utils/types';
 import { DateTime } from 'luxon';
 
-import { validMintNftPurchaseEvent } from '../builderNfts/constants';
 import type { BuilderInfo } from '../builders/interfaces';
 import { normalizeLast14DaysRank } from '../builders/utils/normalizeLast14DaysRank';
 import { scoutProtocolBuilderNftContractAddress, scoutProtocolChainId } from '../protocol/constants';
 
-async function getScoutedBuildersUsingProtocolBuilderNfts({ scoutId }: { scoutId: string }): Promise<BuilderInfo[]> {
-  const wallets = await prisma.scoutWallet.findMany({
-    where: {
-      scoutId
-    }
-  });
+async function getScoutedBuildersUsingProtocolBuilderNfts({
+  scoutIdInView,
+  loggedInScoutId
+}: {
+  scoutIdInView: string;
+  loggedInScoutId?: string;
+}): Promise<BuilderInfo[]> {
+  const scoutIds = [loggedInScoutId, scoutIdInView].filter(isTruthy);
 
-  if (wallets.length === 0) {
-    log.info('No wallets found for scout', { scoutId });
-    return [];
-  }
-
-  const scoutedBuilderNfts = await prisma.scoutNft.findMany({
+  const scoutedNfts = await prisma.scoutNft.findMany({
     where: {
-      walletAddress: {
-        in: wallets.map((wallet) => wallet.address.toLowerCase())
+      scoutWallet: {
+        scoutId: scoutIdInView
       },
       builderNft: {
         chainId: scoutProtocolChainId,
         contractAddress: scoutProtocolBuilderNftContractAddress()
       }
     },
-    include: {
+    select: {
+      balance: true,
       builderNft: {
         select: {
           tokenId: true
+        }
+      },
+      scoutWallet: {
+        select: {
+          scoutId: true
         }
       }
     }
   });
 
   // Get unique builder token IDs since multiple wallets may own the same NFT
-  const uniqueTokenIds = Array.from(new Set(scoutedBuilderNfts.map((nft) => nft.builderNft.tokenId)));
+  const uniqueTokenIds = Array.from(new Set(scoutedNfts.map((nft) => nft.builderNft.tokenId)));
 
   // Get builder info for each unique token ID
   const builders = await prisma.scout.findMany({
@@ -101,66 +104,90 @@ async function getScoutedBuildersUsingProtocolBuilderNfts({ scoutId }: { scoutId
           tokenId: true,
           congratsImageUrl: true,
           estimatedPayout: true,
-          nftSoldEvents: scoutId
-            ? {
-                where: {
-                  builderEvent: {
-                    season: getCurrentSeasonStart()
-                  },
-                  ...validMintNftPurchaseEvent,
-                  scoutWallet: {
-                    scoutId
+          nftOwners:
+            scoutIds.length > 0
+              ? {
+                  where: {
+                    scoutWallet: {
+                      scoutId: {
+                        in: scoutIds
+                      }
+                    }
                   }
-                },
-                select: {
-                  tokensPurchased: true
                 }
-              }
-            : undefined
+              : undefined
         }
       }
     }
   });
 
-  return builders.map((builder) => ({
-    ...builder,
-    nftImageUrl: builder.builderNfts[0].imageUrl,
-    nftType: builder.builderNfts[0].nftType,
-    congratsImageUrl: builder.builderNfts[0].congratsImageUrl,
-    price: builder.builderNfts[0].currentPrice ?? BigInt(0),
-    level: builder.userSeasonStats[0]?.level ?? 0,
-    estimatedPayout: builder.builderNfts[0]?.estimatedPayout ?? 0,
-    last14DaysRank: normalizeLast14DaysRank(builder.builderCardActivities[0]),
-    nftsSoldToScout: builder.builderNfts[0].nftSoldEvents.reduce((acc, event) => acc + (event.tokensPurchased || 0), 0)
-  }));
+  return builders
+    .map((builder) => {
+      const nftsSoldToLoggedInScout = scoutedNfts.find((s) => s.scoutWallet.scoutId === loggedInScoutId)?.balance || 0;
+      const nftsSoldToScoutInView =
+        loggedInScoutId === scoutIdInView
+          ? 0 // dont show this number if scout is looking at their own profile
+          : scoutedNfts.find((s) => s.scoutWallet.scoutId === scoutIdInView)?.balance || 0;
+      if (nftsSoldToScoutInView === 0 || loggedInScoutId === scoutIdInView) {
+        return null;
+      }
+      return {
+        ...builder,
+        nftImageUrl: builder.builderNfts[0].imageUrl,
+        nftType: builder.builderNfts[0].nftType,
+        congratsImageUrl: builder.builderNfts[0].congratsImageUrl,
+        price: builder.builderNfts[0].currentPrice ?? BigInt(0),
+        level: builder.userSeasonStats[0]?.level ?? 0,
+        estimatedPayout: builder.builderNfts[0]?.estimatedPayout ?? 0,
+        last14DaysRank: normalizeLast14DaysRank(builder.builderCardActivities[0]),
+        nftsSoldToScoutInView,
+        nftsSoldToLoggedInScout
+      };
+    })
+    .filter(isTruthy);
 }
 
-export async function getScoutedBuilders({ scoutId }: { scoutId: string }): Promise<BuilderInfo[]> {
+export async function getScoutedBuilders({
+  loggedInScoutId,
+  scoutIdInView
+}: {
+  loggedInScoutId?: string;
+  scoutIdInView: string;
+}): Promise<BuilderInfo[]> {
+  const scoutIds = [loggedInScoutId, scoutIdInView].filter(isTruthy);
   if (getPlatform() === 'onchain_webapp') {
-    return getScoutedBuildersUsingProtocolBuilderNfts({ scoutId });
+    return getScoutedBuildersUsingProtocolBuilderNfts({ scoutIdInView, loggedInScoutId });
   }
 
-  const nftPurchaseEvents = await prisma.nFTPurchaseEvent.findMany({
+  const scoutedNfts = await prisma.scoutNft.findMany({
     where: {
+      scoutWallet: {
+        scoutId: {
+          in: scoutIds
+        }
+      },
       builderNft: {
         season: getCurrentSeasonStart()
-      },
-      scoutWallet: {
-        scoutId
       }
     },
     select: {
-      tokensPurchased: true,
+      balance: true,
       builderNft: {
         select: {
+          id: true,
           builderId: true,
           nftType: true
+        }
+      },
+      scoutWallet: {
+        select: {
+          scoutId: true
         }
       }
     }
   });
 
-  const uniqueBuilderIds = Array.from(new Set(nftPurchaseEvents.map((event) => event.builderNft.builderId)));
+  const uniqueBuilderIds = Array.from(new Set(scoutedNfts.map((nft) => nft.builderNft.builderId)));
 
   const builders = await prisma.scout.findMany({
     where: {
@@ -181,7 +208,10 @@ export async function getScoutedBuilders({ scoutId }: { scoutId: string }): Prom
       },
       builderNfts: {
         where: {
-          season: getCurrentSeasonStart()
+          season: getCurrentSeasonStart(),
+          id: {
+            in: scoutedNfts.map((nft) => nft.builderNft.id)
+          }
         },
         select: {
           contractAddress: true,
@@ -189,20 +219,6 @@ export async function getScoutedBuilders({ scoutId }: { scoutId: string }): Prom
           // TODO: use the currentPriceInScoutToken when we move to $SCOUT
           currentPrice: true,
           nftType: true,
-          nftSoldEvents: {
-            where: {
-              walletAddress: {
-                not: null
-              }
-            },
-            include: {
-              scoutWallet: {
-                select: {
-                  scoutId: true
-                }
-              }
-            }
-          },
           congratsImageUrl: true,
           estimatedPayout: true
         }
@@ -225,41 +241,37 @@ export async function getScoutedBuilders({ scoutId }: { scoutId: string }): Prom
   });
 
   return builders.flatMap((builder) => {
-    return builder.builderNfts
-      .map((nft) => {
-        const nftsSoldData = nft.nftSoldEvents.reduce(
-          (acc, event) => {
-            acc.total += event.tokensPurchased;
-            if (event.scoutWallet?.scoutId === scoutId) {
-              acc.toScout += event.tokensPurchased;
-            }
-            return acc;
-          },
-          { total: 0, toScout: 0 }
-        );
+    const nftsSoldToLoggedInScout = scoutedNfts
+      .filter((s) => s.builderNft.builderId === builder.id && s.scoutWallet.scoutId === loggedInScoutId)
+      .reduce((acc, nft) => acc + nft.balance, 0);
+    const nftsSoldToScoutInView =
+      loggedInScoutId === scoutIdInView
+        ? 0 // dont show this number if scout is looking at their own profile
+        : scoutedNfts
+            .filter((s) => s.builderNft.builderId === builder.id && s.scoutWallet.scoutId === scoutIdInView)
+            .reduce((acc, nft) => acc + nft.balance, 0);
+    if (nftsSoldToScoutInView === 0 && loggedInScoutId !== scoutIdInView) {
+      return [];
+    }
+    return builder.builderNfts.map((nft) => {
+      const nftData: BuilderInfo = {
+        id: builder.id,
+        nftImageUrl: nft.imageUrl,
+        path: builder.path,
+        displayName: builder.displayName,
+        builderStatus: builder.builderStatus!,
+        nftsSoldToScoutInView,
+        nftsSoldToLoggedInScout,
+        price: nft.currentPrice ?? 0,
+        last14DaysRank: normalizeLast14DaysRank(builder.builderCardActivities[0]),
+        nftType: nft.nftType,
+        gemsCollected: builder.userWeeklyStats[0]?.gemsCollected ?? 0,
+        congratsImageUrl: nft.congratsImageUrl,
+        estimatedPayout: nft.estimatedPayout ?? 0,
+        level: builder.userSeasonStats[0]?.level ?? 0
+      };
 
-        if (nftsSoldData.toScout === 0) {
-          return null;
-        }
-
-        const nftData: BuilderInfo = {
-          id: builder.id,
-          nftImageUrl: nft.imageUrl,
-          path: builder.path,
-          displayName: builder.displayName,
-          builderStatus: builder.builderStatus!,
-          nftsSoldToScout: nftsSoldData.toScout,
-          price: nft.currentPrice ?? 0,
-          last14DaysRank: normalizeLast14DaysRank(builder.builderCardActivities[0]),
-          nftType: nft.nftType,
-          gemsCollected: builder.userWeeklyStats[0]?.gemsCollected ?? 0,
-          congratsImageUrl: nft.congratsImageUrl,
-          estimatedPayout: nft.estimatedPayout ?? 0,
-          level: builder.userSeasonStats[0]?.level ?? 0
-        };
-
-        return nftData;
-      })
-      .filter((nft) => nft !== null) as BuilderInfo[];
+      return nftData;
+    }) as BuilderInfo[];
   });
 }


### PR DESCRIPTION
- checked that the card on a builder's builder page shows my NFT count
- checked that my private and public profiles only view NFT count on the cards when i'm looking at them
- checked that my public profile shows the number above the card when looking in incognito
- checked that my nft count appears when looking at someone else's Scout page