### PR TITLE
fix closing modals on iOS

### DIFF
--- a/packages/scoutgame-ui/src/components/common/Dialog.tsx
+++ b/packages/scoutgame-ui/src/components/common/Dialog.tsx
@@ -29,6 +29,7 @@ function CloseButton({ onClick }: { onClick: () => void }) {
       aria-label='close'
       onClick={onClick}
       sx={{
+        zIndex: 1, // necessary for iOS for some reason
         position: 'absolute',
         right: 8,
         top: 8


### PR DESCRIPTION
Tested with an iOS phone and debugging changes in prod. i can't explain it but it was a hunch, i think position absolute is throwing safari off