### PR TITLE
tweak the notifications icon to match other icons

### DIFF
--- a/packages/scoutgame-ui/src/components/common/Navigation/Header.tsx
+++ b/packages/scoutgame-ui/src/components/common/Navigation/Header.tsx
@@ -29,6 +29,7 @@ import { useAction } from 'next-safe-action/hooks';
 import { Link } from 'next-view-transitions';
 import type { MouseEvent } from 'react';
 import { useState } from 'react';
+import { IoIosNotificationsOutline } from 'react-icons/io';
 
 import { useGetUnreadNotificationsCount } from '../../../hooks/api/notifications';
 import { useIsFarcasterFrame } from '../../../hooks/useIsFarcasterFrame';
@@ -96,10 +97,13 @@ export function Header() {
                     <Link href='/notifications'>
                       <IconButton size='small' sx={{ mr: { xs: 1, md: unreadNotificationsCount?.count ? 1.5 : 1 } }}>
                         <Badge badgeContent={unreadNotificationsCount?.count ?? 0} color='error'>
-                          <NotificationsOutlinedIcon
-                            sx={{
-                              color: 'text.primary',
-                              animation: unreadNotificationsCount?.count ? 'bell-ring 2s ease-in-out infinite' : 'none'
+                          <IoIosNotificationsOutline
+                            style={{
+                              fontSize: '26px',
+                              color: 'var(--mui-palette-secondary-light)',
+                              animation: unreadNotificationsCount?.count
+                                ? 'bell-ring 1.5s ease-in-out infinite'
+                                : 'none'
                             }}
                           />
                         </Badge>

--- a/packages/scoutgame-ui/src/theme/colors.ts
+++ b/packages/scoutgame-ui/src/theme/colors.ts
@@ -2,7 +2,7 @@ export const brandColor = '#A06CD5'; // purple
 export const purpleDisabled = '#332245';
 export const secondaryText = '#69DDFF'; // blue
 export const blackText = '#191919'; // black
-export const secondaryLightText = '#D8E1FF'; // light blue
+export const secondaryLightText = '#D8E1FF'; // light grey
 export const secondaryDarkText = '#0580A4'; // dark blue
 export const primaryTextColorDarkMode = '#D8E1FF';
 


### PR DESCRIPTION
The icons are actually slightly off-white and the outline is noticeably thicker than other icons. I also sped up the animation slightly..:
<img width="342" alt="image" src="https://github.com/user-attachments/assets/a3b6e9f4-2d59-4ad0-a1c7-c7af6cd9cb32" />

Updated:
<img width="536" alt="image" src="https://github.com/user-attachments/assets/78e26a11-333d-4fd5-8e1c-446a9c6a5e2d" />

