### PR TITLE
combine payouts for scouts with multuiple wallets

### DIFF
--- a/packages/scoutgame/src/protocol/calculateWeeklyClaims.ts
+++ b/packages/scoutgame/src/protocol/calculateWeeklyClaims.ts
@@ -210,7 +210,7 @@ export async function calculateWeeklyClaims({
         normalisationScale,
         rank: index + 1,
         weeklyAllocatedTokens,
-        owners: { byWallet: [], byScoutId: ownersByScoutId }
+        owners: { byScoutId: ownersByScoutId }
       });
 
       const builderEventId = uuid();

--- a/packages/scoutgame/src/protocol/resolveTokenOwnershipForBuilder.ts
+++ b/packages/scoutgame/src/protocol/resolveTokenOwnershipForBuilder.ts
@@ -7,6 +7,19 @@ import { validMintNftPurchaseEvent } from '../builderNfts/constants';
 import type { PartialNftPurchaseEvent } from '../tokens/getTokensCountForWeekWithNormalisation';
 import { mapPurchaseEventsToOwnership } from '../tokens/mapPurchaseEventsToOwnership';
 
+export type TokenOwnershipForBuilder = {
+  byScoutId: {
+    scoutId: string;
+    totalNft: number;
+    totalStarter: number;
+  }[];
+  byWallet: {
+    wallet: Address;
+    totalNft: number;
+    totalStarter: number;
+  }[];
+};
+
 export async function getNftPurchaseEvents({
   week,
   builderId,
@@ -68,19 +81,6 @@ export async function getNftPurchaseEvents({
       )
     );
 }
-
-export type TokenOwnershipForBuilder = {
-  byScoutId: {
-    scoutId: string;
-    totalNft: number;
-    totalStarter: number;
-  }[];
-  byWallet: {
-    wallet: Address;
-    totalNft: number;
-    totalStarter: number;
-  }[];
-};
 
 export async function resolveTokenOwnershipForBuilder({
   week,

--- a/packages/scoutgame/src/tokens/__tests__/divideTokensBetweenDeveloperAndHolders.spec.ts
+++ b/packages/scoutgame/src/tokens/__tests__/divideTokensBetweenDeveloperAndHolders.spec.ts
@@ -40,18 +40,6 @@ describe('divideTokensBetweenDeveloperAndHolders', () => {
       normalisationFactor,
       normalisationScale,
       owners: {
-        byWallet: [
-          {
-            totalNft: 10,
-            totalStarter: 0,
-            wallet: userAddress1
-          },
-          {
-            totalNft: 5,
-            totalStarter: 2,
-            wallet: userAddress2
-          }
-        ],
         byScoutId: [
           {
             totalNft: 10,
@@ -75,10 +63,6 @@ describe('divideTokensBetweenDeveloperAndHolders', () => {
           total: 17
         },
         earnableTokens: parseUnits('2400', devTokenDecimals),
-        tokensPerScoutByWallet: expect.arrayContaining<TokenDistribution['tokensPerScoutByWallet'][number]>([
-          { wallet: userAddress1, nftTokens: 10, erc20Tokens: BigInt('1119999999999999928320') },
-          { wallet: userAddress2, nftTokens: 5, erc20Tokens: BigInt('799999999999999964160') }
-        ]),
         tokensPerScoutByScoutId: expect.arrayContaining<TokenDistribution['tokensPerScoutByScoutId'][number]>([
           { scoutId: userId1, nftTokens: 10, erc20Tokens: BigInt('1119999999999999928320') },
           { scoutId: userId2, nftTokens: 5, erc20Tokens: BigInt('799999999999999964160') }
@@ -87,7 +71,7 @@ describe('divideTokensBetweenDeveloperAndHolders', () => {
       })
     );
 
-    const totalTokensDistributed = result.tokensPerScoutByWallet.reduce(
+    const totalTokensDistributed = result.tokensPerScoutByScoutId.reduce(
       (acc, scout) => acc + scout.erc20Tokens,
       BigInt(0)
     );
@@ -102,8 +86,7 @@ describe('divideTokensBetweenDeveloperAndHolders', () => {
         normalisationFactor,
         normalisationScale,
         owners: {
-          byScoutId: [],
-          byWallet: []
+          byScoutId: []
         }
       })
     ).toThrow('Invalid rank provided. Must be a number greater than 0');

--- a/packages/scoutgame/src/tokens/divideTokensBetweenDeveloperAndHolders.ts
+++ b/packages/scoutgame/src/tokens/divideTokensBetweenDeveloperAndHolders.ts
@@ -23,11 +23,6 @@ export type TokenDistribution = {
     total: number;
   };
   earnableTokens: bigint;
-  tokensPerScoutByWallet: {
-    wallet: Address;
-    nftTokens: number;
-    erc20Tokens: bigint;
-  }[];
   tokensPerScoutByScoutId: {
     scoutId: string;
     nftTokens: number;

--- a/packages/scoutgame/src/tokens/divideTokensBetweenDeveloperAndHolders.ts
+++ b/packages/scoutgame/src/tokens/divideTokensBetweenDeveloperAndHolders.ts
@@ -55,27 +55,18 @@ export function divideTokensBetweenDeveloperAndHolders({
   weeklyAllocatedTokens: bigint;
   normalisationFactor: bigint;
   normalisationScale: bigint;
-  owners: TokenOwnershipForBuilder;
+  owners: Pick<TokenOwnershipForBuilder, 'byScoutId'>;
 }): TokenDistribution {
   if (rank < 1 || typeof rank !== 'number') {
     throw new InvalidInputError('Invalid rank provided. Must be a number greater than 0');
   }
 
   // Calculate the total number of NFTs purchased by each scout
-  const nftSupply = owners.byWallet.reduce((acc, owner) => acc + owner.totalNft, 0);
-  const starterSupply = owners.byWallet.reduce((acc, owner) => acc + owner.totalStarter, 0);
+  const nftSupply = owners.byScoutId.reduce((acc, owner) => acc + owner.totalNft, 0);
+  const starterSupply = owners.byScoutId.reduce((acc, owner) => acc + owner.totalStarter, 0);
 
   const earnableTokens =
     (calculateEarnableTokensForRank({ rank, weeklyAllocatedTokens }) * normalisationFactor) / normalisationScale;
-
-  const tokensPerScoutByWallet = owners.byWallet.map((owner) => {
-    const scoutReward = calculateRewardForScout({
-      purchased: { default: owner.totalNft, starterPack: owner.totalStarter },
-      supply: { default: nftSupply, starterPack: starterSupply },
-      scoutsRewardPool: earnableTokens
-    });
-    return { wallet: owner.wallet, nftTokens: owner.totalNft, erc20Tokens: scoutReward };
-  });
 
   const tokensPerScoutByScoutId = owners.byScoutId.map((owner) => {
     const scoutReward = calculateRewardForScout({
@@ -96,7 +87,6 @@ export function divideTokensBetweenDeveloperAndHolders({
       total: nftSupply + starterSupply
     },
     earnableTokens,
-    tokensPerScoutByWallet,
     tokensPerScoutByScoutId,
     tokensForDeveloper
   };


### PR DESCRIPTION
@Devorein question: in "calculateWeeklyStats", 'tokenReceipts' is built separately from the claims list. I didn't de-dupe the payouts for token receipts but should i be? i wonder if this could could be simplified by making tokenReceipts derived from the claims, or are they two separate concepts?