### PR TITLE
Add POIDH to Arbitrum partner rewards page

### DIFF
--- a/apps/scoutgame/components/info/partner-rewards/ArbitrumPage.tsx
+++ b/apps/scoutgame/components/info/partner-rewards/ArbitrumPage.tsx
@@ -258,6 +258,14 @@ function Document() {
                 </TableCell>
                 <TableCell sx={{ border: 'none', p: 1 }}>Community development toolkit</TableCell>
               </TableRow>
+              <TableRow>
+                <TableCell sx={{ border: 'none', p: 1 }}>
+                  <Link href='https://github.com/picsoritdidnthappen/poidh-app' target='_blank'>
+                    POIDH
+                  </Link>
+                </TableCell>
+                <TableCell sx={{ border: 'none', p: 1 }}>Crypto Bounties</TableCell>
+              </TableRow>
             </TableBody>
           </Table>
         </Stack>


### PR DESCRIPTION
## Summary
- Added POIDH (Crypto Bounties) to the list of qualified Arbitrum repositories
- Repository URL: https://github.com/picsoritdidnthappen/poidh-app
- Description: Crypto Bounties

## Test plan
- [ ] Verify the new entry appears correctly in the Arbitrum partner rewards page
- [ ] Ensure the link to the POIDH repository works correctly
- [ ] Check that the table formatting remains consistent

🤖 Generated with [Claude Code](https://claude.ai/code)