### PR TITLE
Update airdrop page copy for Season 2

### DIFF
--- a/apps/scoutgame/app/(general)/airdrop/page.tsx
+++ b/apps/scoutgame/app/(general)/airdrop/page.tsx
@@ -82,7 +82,7 @@ export default function AirdropPage() {
               <Typography>Hold!</Typography>
             </Stack>
           </Stack>
-          <Typography>Stack up bonuses in future airdrops!</Typography>
+          <Typography>Stack up bonuses in future airdrops by holding ALL previous season airdrops!</Typography>
           <Stack flexDirection='row' gap={4} alignItems='center' justifyContent='center'>
             <Box sx={{ display: { xs: 'none', md: 'block' } }}>
               <Image src='/images/diamond.png' alt='Diamond Icon' width={125} height={125} />
@@ -91,12 +91,6 @@ export default function AirdropPage() {
               <Image src='/images/diamond.png' alt='Diamond Icon' width={90} height={90} />
             </Box>
             <Stack flexDirection='column' gap={1}>
-              <Typography>
-                Season 2:{' '}
-                <Typography component='span' color='green'>
-                  +15% Bonus
-                </Typography>
-              </Typography>
               <Typography>
                 Season 3:{' '}
                 <Typography component='span' color='green'>
@@ -125,8 +119,8 @@ export default function AirdropPage() {
               </Typography>
             </Stack>
             <Typography>
-              Selling any portion of your airdrop will disqualify you from Diamond Hands Rewards. You will receive a
-              soulbound Paper Hands token that will affect your future airdrops.
+              Selling any portion of your current OR previous season airdrops will disqualify you from Diamond Hands
+              Rewards.
             </Typography>
           </Stack>
         </Paper>
@@ -179,7 +173,7 @@ export default function AirdropPage() {
                 Donate your DEV tokens to the Scout Game Open Source Grants Program.
               </Typography>{' '}
               The Grants will be distributed to open source developers playing Scout Game. <br /> <br />
-              Donate 100% of your airdrop to open source and instantly earn Season 2's bonus while funding critical
+              Donate 100% of your airdrop to open source and instantly earn Season 3's bonus while funding critical
               projects.
             </Typography>
           </Paper>
@@ -202,7 +196,7 @@ export default function AirdropPage() {
               <Typography component='span' color='green'>
                 Holding pays off.
               </Typography>{' '}
-              Keep 100% of your airdrop and you'll stack bonus rewards in future seasons.
+              Keep 100% of your current and previous season airdrops and you'll stack bonus rewards in future seasons.
             </Typography>
           </Paper>
         </Stack>

--- a/apps/scoutgame/components/airdrop/components/AlreadyClaimedStep.tsx
+++ b/apps/scoutgame/components/airdrop/components/AlreadyClaimedStep.tsx
@@ -17,12 +17,12 @@ export function AlreadyClaimedStep() {
         </Typography>
         {isDesktop ? (
           <Typography variant='h6' textAlign='center' fontWeight={400}>
-            Play this season to earn your spot in the next <br /> airdrop. Get started by drafting Developers <br />{' '}
+            Play this season to earn your spot in the next <br /> airdrop. Get started by scouting Developers <br />{' '}
             before the season officially begins!
           </Typography>
         ) : (
           <Typography>
-            Play this season to earn your spot in the next airdrop. Get started by drafting Developers before the season
+            Play this season to earn your spot in the next airdrop. Get started by scouting Developers before the season
             officially begins!
           </Typography>
         )}

--- a/apps/scoutgame/components/airdrop/components/NotQualifiedStep.tsx
+++ b/apps/scoutgame/components/airdrop/components/NotQualifiedStep.tsx
@@ -26,12 +26,12 @@ export function NotQualifiedStep() {
         </Typography>
         {isDesktop ? (
           <Typography variant='h6' textAlign='center' fontWeight={400}>
-            Play this season to earn your spot in the next <br /> airdrop. Get started by drafting Developers <br />{' '}
+            Play this season to earn your spot in the next <br /> airdrop. Get started by scouting Developers <br />{' '}
             before the season officially begins!
           </Typography>
         ) : (
           <Typography>
-            Play this season to earn your spot in the next airdrop. Get started by drafting Developers before the season
+            Play this season to earn your spot in the next airdrop. Get started by scouting Developers before the season
             officially begins!
           </Typography>
         )}

--- a/apps/scoutgame/components/airdrop/components/PlayButton.tsx
+++ b/apps/scoutgame/components/airdrop/components/PlayButton.tsx
@@ -3,7 +3,7 @@ import Link from 'next/link';
 
 export function PlayButton() {
   return (
-    <Link href='/scout'>
+    <Link href='/'>
       <Button
         variant='blue'
         sx={{

--- a/apps/scoutgame/components/airdrop/components/StartClaimStep.tsx
+++ b/apps/scoutgame/components/airdrop/components/StartClaimStep.tsx
@@ -30,19 +30,18 @@ export function StartClaimStep({ isLoading }: { isLoading: boolean }) {
           }}
         >
           Claim period for <br />
-          Season 1 Rewards is OPEN!
+          Season 2 Rewards is OPEN!
         </Typography>
         {isDesktop ? (
           <Typography variant='h6'>
-            Top Players from the Scout Game Preaseason, you've <br />
-            secured your place in the airdrop! Claim your DEV <br />
-            tokens at the start of each season for the next 10 <br />
-            seasons.
+            Top Players from Season 1, you've secured your <br />
+            place in the airdrop! Claim your DEV tokens at the <br />
+            start of each season for the next 9 seasons.
           </Typography>
         ) : (
           <Typography>
-            Top Players from the Scout Game Preaseason, you've secured your place in the airdrop! Claim your DEV tokens
-            at the start of each season for the next 10 seasons.
+            Top Players from Season 1, you've secured your place in the airdrop! Claim your DEV tokens at the start of
+            each season for the next 9 seasons.
           </Typography>
         )}
         {isLoading ? (

--- a/apps/scoutgame/components/airdrop/components/TokenClaimSuccessStep.tsx
+++ b/apps/scoutgame/components/airdrop/components/TokenClaimSuccessStep.tsx
@@ -68,11 +68,11 @@ export function TokenClaimSuccessStep({ donationPercentage }: { donationPercenta
           ) : null}
           {isDesktop ? (
             <Typography variant='h6' textAlign='center'>
-              Now, let's go Bid on some developers and <br /> build your team before the season begins!
+              Now, let's go Scout some developers and <br /> build your team before the season begins!
             </Typography>
           ) : (
             <Typography variant='h6' textAlign='center'>
-              Now, let's go Bid on some developers and build your team before the season begins!
+              Now, let's go Scout some developers and build your team before the season begins!
             </Typography>
           )}
           <PlayButton />


### PR DESCRIPTION
## Summary
- Updated all airdrop page copy to reflect Season 2 claim period
- Maintained existing page design while updating content
- Updated terminology from bidding/drafting to scouting

## Changes Made

### Season and Timeline Updates
- Changed claim period announcement from "Season 1" to "Season 2"
- Updated eligibility from "Preseason players/10 seasons" to "Season 1 players/9 seasons"

### Diamond Hands Rewards Updates
- Removed Season 2 bonus tier (starting with Season 3: +20%)
- Added emphasis on holding ALL previous season airdrops for bonuses
- Updated sell warning to clarify "current OR previous season airdrops" disqualifies from rewards

### Terminology Updates
- Changed all instances of "Bid" to "Scout"
- Changed all instances of "drafting" to "scouting"
- Updated Play button to redirect to homepage (/) instead of /scout

### Other Updates
- Changed donation instant bonus reference from "Season 2's bonus" to "Season 3's bonus"
- Updated Hold section to emphasize keeping both current and previous season airdrops

## Test plan
- [ ] Verify airdrop page displays correctly at /airdrop
- [ ] Confirm all copy updates are visible
- [ ] Test wallet connection flow
- [ ] Verify Play button redirects to homepage
- [ ] Check responsive design on mobile

🤖 Generated with [Claude Code](https://claude.ai/code)