### PR TITLE
Add GoodDollar ScoutGame Telegram channel link

### DIFF
--- a/apps/scoutgame/components/info/partner-rewards/GoodDollarPage.tsx
+++ b/apps/scoutgame/components/info/partner-rewards/GoodDollarPage.tsx
@@ -176,7 +176,7 @@ function Document() {
           </Link>
         </ListItem>
       </List>
-      
+
       <Typography mt={1}>
         For getting updates on new scoutgame tickets available, or keep up-to-date around our other open-source
         contribution opportunities, please join the gooddollar scoutgame channel:{' '}

--- a/apps/scoutgame/components/info/partner-rewards/GoodDollarPage.tsx
+++ b/apps/scoutgame/components/info/partner-rewards/GoodDollarPage.tsx
@@ -176,6 +176,14 @@ function Document() {
           </Link>
         </ListItem>
       </List>
+      
+      <Typography mt={1}>
+        For getting updates on new scoutgame tickets available, or keep up-to-date around our other open-source
+        contribution opportunities, please join the gooddollar scoutgame channel:{' '}
+        <Link href='https://t.me/gooddollarbounties/4115' target='_blank' rel='noreferrer'>
+          https://t.me/gooddollarbounties/4115
+        </Link>
+      </Typography>
 
       <Typography mt={1}>Join us and contribute to building the future of financial freedom!</Typography>
 


### PR DESCRIPTION
## Summary
- Added information about the GoodDollar ScoutGame Telegram channel to the partner rewards page
- Users can now find the link to join the channel for updates on new tickets and open-source contribution opportunities

## Changes
- Added a new paragraph at the bottom of the "Join our vibrant community for updates & collaboration" section
- Includes the Telegram channel link: https://t.me/gooddollarbounties/4115

## Test plan
- [x] Verify the text appears correctly on the GoodDollar partner rewards page
- [x] Verify the Telegram link is clickable and opens in a new tab
- [x] Check that the formatting matches the existing page style

🤖 Generated with [Claude Code](https://claude.ai/code)