### PR TITLE
Add Basic tier to GoodDollar partner rewards

### DIFF
--- a/apps/scoutgame/components/info/partner-rewards/GoodDollarPage.tsx
+++ b/apps/scoutgame/components/info/partner-rewards/GoodDollarPage.tsx
@@ -14,6 +14,10 @@ export function GoodDollarPage({ infoPageImage }: { infoPageImage: string }) {
 
 const tiers = [
   {
+    name: 'Basic',
+    reward: '$25 | 250,000 G$'
+  },
+  {
     name: 'Common',
     reward: '$50 | 500,000 G$'
   },


### PR DESCRIPTION
## Summary
- Added Basic tier ($25 / 250,000 G$) to the GoodDollar partner rewards table
- Positioned above Common tier as requested
- Maintains existing tier order: Basic → Common → Rare → Epic → Mythic → Legendary

## Test plan
- [ ] Verify the Basic tier appears correctly in the rewards table at https://scoutgame.xyz/info/partner-rewards/gooddollar
- [ ] Confirm the reward amount displays as "$25 | 250,000 G$"
- [ ] Check that the tier order is correct

🤖 Generated with [Claude Code](https://claude.ai/code)